### PR TITLE
feat: added pg-backup-cronify

### DIFF
--- a/pg-backup-cronify/.env.eg
+++ b/pg-backup-cronify/.env.eg
@@ -1,0 +1,11 @@
+PG_USER=myname
+PG_PASSWORD=mypwd
+PG_DATABASE=mydb
+PG_PORT=5432
+PG_HOST=172.17.0.1
+
+BUNNY_HOSTNAME=storage.bunnycdn.com
+BUNNY_STORAGE_NAME=cron-job
+BUNNY_PASSWORD=
+
+

--- a/pg-backup-cronify/.gitignore
+++ b/pg-backup-cronify/.gitignore
@@ -1,0 +1,2 @@
+backups
+.env

--- a/pg-backup-cronify/Dockerfile
+++ b/pg-backup-cronify/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:latest AS builder
+
+WORKDIR /app
+
+# just copying main script is enough
+# it does not have any 3-rd party deps
+COPY go.mod main.go .
+
+RUN go build -o main .
+
+FROM postgres AS final
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+WORKDIR /app
+
+COPY --from=builder /app/main /app/main
+
+CMD ["/app/main"]

--- a/pg-backup-cronify/README.md
+++ b/pg-backup-cronify/README.md
@@ -1,0 +1,49 @@
+# Postgres Nightly Backup to Bunny CDN
+
+This repo is having a setup to schedule backups of a Postgre DB, using Docker, `pg_dump`, and a Golang script to handle backup creation and upload to Bunny CDN. It would then exit out to minimize the system load.
+
+## Overview
+
+- **Database Backup**: Uses `pg_dump` to create  snapshot of the DB in `.sql` format.
+- **Backup Upload**: A Go script uploads the backup to Bunny CDN with retry logic.
+
+## Salient Features
+
+1. **Multi-stage Docker Build**  
+   - Uses a multi-stage Dockerfile to compile the Go upload script in one stage and transfer it to a PostgreSQL-based image in the next, avoiding the need for local `pg_dump` installation. Which would exit out once completed to reduce load on system.
+   
+2. **Automated Cron Job**  
+   - A bash script registers a cron job to execute the Docker Compose setup every night at midnight can be configured to run any time. for syntx visit https://crontab.guru.
+   - Logs output to `log.txt` in the docker compos directory.
+
+3. **Retry Mechanism**  
+   - Both the backup and upload processes have retry mechanisms to handle errors with up to 10 attempts.
+
+4. **Cross-platform Compatibility**  
+   - Using Docker avoids dependencies on the host system, ensuring compatibility across platforms.
+
+## Setup Instructions
+After cloning the app
+1. **Environment Variables**  
+   Copy .env.eg to .env and set DB and BunnyCDN creds.
+2. **Build & start the container for 1st time**
+    ```bash
+    docker-compose up -d
+    ```
+    Build the image for 1st time & run the container to ensure it is ready to run on schduled time 
+    
+    Check your uploaded backup to BunnyCDN dashboard and in backups dir locally.
+2. **Register Cron Job**  
+   Chmod the sh script & run the bash script below to register the nightly cron job:
+   ```bash
+    chmod +x setup_cron.sh
+    sudo bash setup_cron.sh
+   ```
+   This would scheduled to run the process the at specific time and log the o/p in log.txt file in current dir.
+
+## Notes
+
+- **Dir Structure**: Backups are saved to the `backups/` directory locally.
+- **Omit CDN uploading**: 
+    - Can be configured to store the backup locally
+    - By commenting out the uploading function in golang script and all the auxillary code that function is using.

--- a/pg-backup-cronify/docker-compose.yaml
+++ b/pg-backup-cronify/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  backup:
+    build:
+      context: .
+      target: final
+    env_file: .env
+    environment:
+      - BACKUP_FOLDER=cms
+    # Preserve backup on machine too
+    volumes:
+      - ./backups/:/app/backups

--- a/pg-backup-cronify/go.mod
+++ b/pg-backup-cronify/go.mod
@@ -1,0 +1,3 @@
+module backup-cron
+
+go 1.23.2

--- a/pg-backup-cronify/main.go
+++ b/pg-backup-cronify/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+var (
+	dbUser       = os.Getenv("PG_USER")
+	dbPassword   = os.Getenv("PG_PASSWORD")
+	dbName       = os.Getenv("PG_DATABASE")
+	dbHost       = os.Getenv("PG_HOST")
+	dbPort       = os.Getenv("PG_PORT")
+	backupFolder = os.Getenv("BACKUP_FOLDER")
+	maxRetries   = 10
+	retryDelay   = 2 * time.Second
+	cdnHost      = os.Getenv("BUNNY_HOSTNAME")
+	cdnStorage   = os.Getenv("BUNNY_STORAGE_NAME")
+	cdnAccessKey = os.Getenv("BUNNY_PASSWORD")
+)
+
+func main() {
+	fmt.Print("\n\n\nLaunching backup at: ", getFormattedDate(), "\n")
+	fmt.Println("================================================")
+
+	backupPath, err := pullDBBackup()
+	if err != nil {
+		fmt.Println("Failed to create db backup:", err)
+		os.Exit(1)
+	}
+	if err := uploadToCDN(backupPath); err != nil {
+		fmt.Println("Process failed:", err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Println("Backup completed successfully. Backup file path:", backupPath)
+	os.Exit(1)
+}
+
+func pullDBBackup() (string, error) {
+	backupFileName := fmt.Sprintf("%s_backup.sql", getFormattedDate())
+	backupFolderPath := filepath.Join(getCWD(), "backups", backupFolder)
+	backupFilePath := filepath.Join(backupFolderPath, backupFileName)
+
+	if err := os.MkdirAll(backupFolderPath, os.ModePerm); err != nil {
+		return "", fmt.Errorf("failed to create backup dir: %w", err)
+	}
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		fmt.Printf("Attempt %d/%d: Started pulling backup...\n", attempt, maxRetries)
+
+		cmd := exec.Command("pg_dump", "-U", dbUser, "-h", dbHost, "-p", dbPort, "-d", dbName, "-f", backupFilePath)
+		cmd.Env = append(os.Environ(), fmt.Sprintf("PGPASSWORD=%s", dbPassword))
+
+		if output, err := cmd.CombinedOutput(); err != nil {
+			fmt.Printf("DB backup attempt %d failed: %s\n", attempt, err.Error())
+			fmt.Println(string(output))
+		} else {
+			fmt.Println("DB backup completed successfully:", backupFilePath)
+			return backupFilePath, nil
+		}
+
+		time.Sleep(retryDelay)
+	}
+	return "", errors.New("exceeded maximum retry attempts for db backup")
+}
+
+func getFormattedDate() string {
+	now := time.Now()
+	return fmt.Sprintf("%d_%02d_%02d_%02d_%02d_%02d", now.Year(), int(now.Month()), now.Day(), now.Hour(), now.Minute(), now.Second())
+}
+
+func getCWD() string {
+	dir, _ := os.Getwd()
+	return dir
+}
+
+func uploadToCDN(backupFilePath string) error {
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		fmt.Printf("Attempt %d/%d: Uploading backup to CDN...\n", attempt, maxRetries)
+
+		file, err := os.Open(backupFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to open backup file: %w", err)
+		}
+		defer file.Close()
+
+		req, err := http.NewRequest("PUT", fmt.Sprintf("https://%s/%s/%s/%s", cdnHost, cdnStorage, backupFolder, filepath.Base(backupFilePath)), file)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("AccessKey", cdnAccessKey)
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			fmt.Printf("CDN upload attempt %d failed: %s\n", attempt, err.Error())
+		} else {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusCreated {
+				fmt.Printf("Backup uploaded successfully on attempt %d.\n", attempt)
+				return nil
+			} else {
+				fmt.Printf("Upload failed with status code %d\n", resp.StatusCode)
+			}
+		}
+		time.Sleep(retryDelay)
+	}
+	return errors.New("exceeded maximum retry attempts for CDN upload")
+}

--- a/pg-backup-cronify/setup_cron.sh
+++ b/pg-backup-cronify/setup_cron.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DOCKER_COMPOSE_DIR="$(pwd)"
+
+DOCKER_CMD="$(which docker)"
+
+# create the cron job
+(crontab -l; echo "0 0 * * * cd $DOCKER_COMPOSE_DIR && $DOCKER_CMD compose up >> $DOCKER_COMPOSE_DIR/log.txt 2>&1") | crontab -


### PR DESCRIPTION
This PR introduce PostgressQL data back & upload them to BunnyCDN

This is inside the pg-backup-cronify dir

Top overview:
1. Uses pg_dump for backup
      - It create a file when re-run bring the DB at the state it was at the time of backup
      -  as pg_dump is non-blocking except few ops like Altering Table then it block the backup ops
2. Golang script to push it to CDN.

3. Using system cron to schedules the re-run

First two steps are done using multi-stage Dockerfile.
Cron job is being registered using sh script

Set up commands
```bash
cp .env.eg .env
docker compose up -d
sudo bash setup_cron.sh
```

For more guide please see the README.md